### PR TITLE
Updated region bed

### DIFF
--- a/egg3_config.py
+++ b/egg3_config.py
@@ -30,7 +30,7 @@ ss_beds_inputs = {
     "stage-Fy6fqy040vZV3Gj24vppvJgZ.bed_file ID": "file-G29FqK0433GqqFVy3zgfzZYF",
     "stage-Fy6fqy040vZV3Gj24vppvJgZ.bed_file": "",
     # region coverage
-    "stage-G21GzGj433Gky42j42Q5bJkf.input_bed ID": "file-G29FqK0433GqqFVy3zgfzZYF",
+    "stage-G21GzGj433Gky42j42Q5bJkf.input_bed ID": "file-Fpz2X0Q433GVK5xxPvzqvVPB",
     "stage-G21GzGj433Gky42j42Q5bJkf.input_bed": "",
     # mosdepth
     "stage-Fy6fvYQ40vZV1y8p9GYKPYyQ.bed ID": "file-G29FqK0433GqqFVy3zgfzZYF",


### PR DESCRIPTION
Now uses refseq regions bed. 
Previously used FH regions bed however this does not include SRY, which causes report generation to fail downstream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/egg3_dias_fh_config/4)
<!-- Reviewable:end -->
